### PR TITLE
Fix no embed if no og:description and no image if type defined

### DIFF
--- a/app/utils/rssHandler.ts
+++ b/app/utils/rssHandler.ts
@@ -61,8 +61,8 @@ async function start() {
           if (Object.keys(item).includes(imageKey)) {
             if (
               Object.keys(item[imageKey]).includes("url") &&
-              !Object.keys(item[imageKey]).includes("type") &&
-              !item[imageKey]["type"].startsWith("image")
+              !(Object.keys(item[imageKey]).includes("type") &&
+              !item[imageKey]["type"].startsWith("image"))
             ) {
               imageUrl = item[imageKey]["url"];
             }

--- a/app/utils/rssHandler.ts
+++ b/app/utils/rssHandler.ts
@@ -126,7 +126,11 @@ async function start() {
           if (description == undefined) {
             description = openGraphData.ogDescription
               ? openGraphData.ogDescription
-              : config.forceDescriptionEmbed == true && undefined;
+              : item.description
+              ? item.description
+              : item.content
+              ? item.content
+              : "";
           }
         }
 


### PR DESCRIPTION
- Fix no embed if no og:description (it takes description > content > ""). 

- Missing parentheses when forcing image embed when type is present. 