### PR TITLE
Fix when opengraph url is a relative/bad URL

### DIFF
--- a/app/utils/rssHandler.ts
+++ b/app/utils/rssHandler.ts
@@ -143,14 +143,22 @@ async function start() {
           description = removeHTMLTags(description);
         }
 
+        let uri = openGraphData.ogUrl ? openGraphData.ogUrl : url;
+
+        if (openGraphData.ogUrl) {
+          let regexURL = new RegExp(`(?:(h|H)(t|T)(t|T)(p|P)(s|):\\/\\/|)[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)`)
+
+          if (!regexURL.test(openGraphData.ogUrl)) uri = url;
+        }
+
         if (
-          (!openGraphData.ogUrl && !url) ||
+          !uri ||
           (!openGraphData.ogTitle && !item.title)
         ) {
           embed = undefined;
         } else {
           embed = {
-            uri: openGraphData.ogUrl ? openGraphData.ogUrl : url,
+            uri: uri,
             title: openGraphData.ogTitle ? openGraphData.ogTitle : item.title,
             description: description,
             image: image,


### PR DESCRIPTION
Fix when opengraph url is a relative/bad URL

It is the case for example [It ](https://www.zerohedge.com/crypto/heres-where-grassroots-crypto-adoption-highest)
where the opengraph url tag is 
<meta name="og:url" content="/crypto/heres-where-grassroots-crypto-adoption-highest"/>